### PR TITLE
DSOPS-3  Create TF module template for CD CodePipeline in Client Specific Account

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+#### PR description
+
+What is it for?
+
+#### Testing instructions
+
+-
+-
+
+#### JIRA ticket information
+
+Story: [DSOPS-000](https://jira.theglobeandmail.com/browse/DSOPS-000)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,101 @@
 # aws-cd-codepipeline
 The AWS codepipeline for CD (i.e. deployment). Codepipeline is triggered by a lambda zip archive or an ECS imagedefinitions.json file upload to the S3 artifact bucket in the shared service account. The deploy stage then takes the input artifact and updates the lambda function code or ECS task definition in the current account.
+
+Notes:
+1. All code pipeline output artifacts are encrypted with the default S3 KMS key (alias aws/s3) in the same region.
+2. For ECS and ECR deployment, set `container_image` in the ECS task definition module to the ECR repository URL imported from the shared service account.
+
+## Usage
+### Lambda
+```hcl
+ module "lambda_cd_pipeline" {
+  source = "github.com/globeandmail/aws-cd-codepipeline?ref=1.0"
+
+  name                              = "app-name"
+  deploy_type                       = "lambda"
+  svcs_account_artifact_bucket_arn  = "svcs-account-artifact-bucket-arn"
+  svcs_account_artifact_bucket_id   = "svcs-account-artifact-bucket-id"
+  svcs_account_artifact_object_name = "svcs-account-artifact-object-name"
+  svcs_account_kms_cmk_arn_for_s3   = "svcs-account-kms-cmk-arn-for-s3"
+  lambda_function_name              = "lambda-function-name"
+  require_manual_approval           = true
+  approve_sns_arn                   = "approve-sns-arn"
+  tags                              = {
+                                        Environment = var.environment
+                                      }
+}
+```
+
+### ECS
+```hcl
+module "ecs_cd_pipeline" {
+  source = "github.com/globeandmail/aws-cd-codepipeline?ref=1.0"
+
+  name                              = "app-name"
+  deploy_type                       = "ecs"
+  svcs_account_artifact_bucket_arn  = "svcs-account-artifact-bucket-arn"
+  svcs_account_artifact_bucket_id   = "svcs-account-artifact-bucket-id"
+  svcs_account_artifact_object_name = "svcs-account-artifact-object-name"
+  svcs_account_kms_cmk_arn_for_s3   = "svcs-account-kms-cmk-arn-for-s3"
+  ecs_cluster_name                  = "ecs-cluster-name"
+  ecs_service_name                  = "ecs-service-name"
+  task_execution_role               = "task-execution-role-name"
+  svcs_account_ecr_repository_name  = "svcs-account-ecr-repository-name"
+  svcs_account_ecr_repository_url   = "svcs-account-ecr-repository-url"
+  svcs_account_ecr_repository_arn   = "svcs-account-ecr-repository-arn"
+  require_manual_approval           = true
+  approve_sns_arn                   = "approve-sns-arn"
+  tags                              = {
+                                        Environment = var.environment
+                                      }
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_approve_sns_arn"></a> [approve\_sns\_arn](#input\_approve\_sns\_arn) | (Optional) The ARN of the SNS topic in the approve stage.<br>                Required if var.require\_manual\_approval is true. | `string` | `null` | no |
+| <a name="input_approve_url"></a> [approve\_url](#input\_approve\_url) | (Optional) The URL for review in the approve stage. It should begin with 'http://' or 'https://'. | `string` | `null` | no |
+| <a name="input_deploy_function_name"></a> [deploy\_function\_name](#input\_deploy\_function\_name) | (Optional) The name of the Lambda function in the account that will update the function code. | `string` | `"CodepipelineDeploy"` | no |
+| <a name="input_deploy_type"></a> [deploy\_type](#input\_deploy\_type) | (Required) Must be one of the following ( ecs, lambda ). | `string` | n/a | yes |
+| <a name="input_ecs_artifact_filename"></a> [ecs\_artifact\_filename](#input\_ecs\_artifact\_filename) | (Optional) The name of the ECS deploy artifact. | `string` | `null` | no |
+| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | (Optional) The name of the ECS cluster. Required if var.deploy\_type is ecs. | `string` | `null` | no |
+| <a name="input_ecs_service_name"></a> [ecs\_service\_name](#input\_ecs\_service\_name) | (Optional) The name of the ECS service. Required if var.deploy\_type is ecs. | `string` | `null` | no |
+| <a name="input_lambda_function_alias"></a> [lambda\_function\_alias](#input\_lambda\_function\_alias) | (Optional) The name of the Lambda function alias that gets passed to the UserParameters data in the deploy stage. | `string` | `"live"` | no |
+| <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | (Optional) The name of the lambda function to update. Required if var.deploy\_type is lambda. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name associated with the pipeline and assoicated resources. i.e.: app-name. | `string` | n/a | yes |
+| <a name="input_require_manual_approval"></a> [require\_manual\_approval](#input\_require\_manual\_approval) | (Optional) Create the approval stage in the codepipeline. Defaults to false. | `bool` | `false` | no |
+| <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | (Optional) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.<br>                Defaults to true. | `bool` | `true` | no |
+| <a name="input_svcs_account_artifact_bucket_arn"></a> [svcs\_account\_artifact\_bucket\_arn](#input\_svcs\_account\_artifact\_bucket\_arn) | (Optional) The ARN of the S3 bucket that stores the codebuild artifacts.<br>                The bucket is created in the shared service account.<br>                Required if var.deploy\_type is lambda or ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_artifact_bucket_id"></a> [svcs\_account\_artifact\_bucket\_id](#input\_svcs\_account\_artifact\_bucket\_id) | (Optional) The name of the S3 bucket that stores the codebuild artifacts.<br>                The bucket is created in the shared service account.<br>                Required if var.deploy\_type is lambda or ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_artifact_object_name"></a> [svcs\_account\_artifact\_object\_name](#input\_svcs\_account\_artifact\_object\_name) | (Optional) The key of the S3 object that triggers codepipeline.<br>                The object is created in the shared service account.<br>                Required if var.deploy\_type is lambda or ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_ecr_repository_arn"></a> [svcs\_account\_ecr\_repository\_arn](#input\_svcs\_account\_ecr\_repository\_arn) | (Optional) The ARN of the ECR repository.<br>                The repository is created in the shared service account.<br>                Required if var.deploy\_type is ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_ecr_repository_name"></a> [svcs\_account\_ecr\_repository\_name](#input\_svcs\_account\_ecr\_repository\_name) | (Optional) The name of the ECR repository.<br>                The repository is created in the shared service account.<br>                Required if var.deploy\_type is ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_ecr_repository_url"></a> [svcs\_account\_ecr\_repository\_url](#input\_svcs\_account\_ecr\_repository\_url) | (Optional) The URL of the ECR repository.<br>                The repository is created in the shared service account.<br>                Required if var.deploy\_type is ecs. | `string` | `null` | no |
+| <a name="input_svcs_account_kms_cmk_arn_for_s3"></a> [svcs\_account\_kms\_cmk\_arn\_for\_s3](#input\_svcs\_account\_kms\_cmk\_arn\_for\_s3) | (Optional) The single-region AWS KMS customer managed key ARN for encrypting s3 artifacts.<br>                The key is created in the shared service account.<br>                Required if var.deploy\_type is lambda or ecs. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map` | `{}` | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | (Optional) The name of the ECS task execution role. Required if var.deploy\_type is ecs. | `string` | `"ecsTaskExecutionRole"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_artifact_bucket_arn"></a> [artifact\_bucket\_arn](#output\_artifact\_bucket\_arn) | n/a |
+| <a name="output_artifact_bucket_id"></a> [artifact\_bucket\_id](#output\_artifact\_bucket\_id) | n/a |
+| <a name="output_codepipeline_arn"></a> [codepipeline\_arn](#output\_codepipeline\_arn) | n/a |
+| <a name="output_codepipeline_id"></a> [codepipeline\_id](#output\_codepipeline\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# aws-cd-codepipeline-lambda
-The AWS codepipeline for CD. Codepipeline is initiated by a lambda zip archive upload to the artifact store in the shared service account and then updates the existing function code in the current account.
+# aws-cd-codepipeline
+The AWS codepipeline for CD (i.e. deployment). Codepipeline is triggered by a lambda zip archive or an ECS imagedefinitions.json file upload to the S3 artifact bucket in the shared service account. The deploy stage then takes the input artifact and updates the lambda function code or ECS task definition in the current account.

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -1,0 +1,197 @@
+data "aws_iam_policy_document" "codepipeline_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "codepipeline" {
+  name               = "codepipeline-cd-${var.name}"
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_assume.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "codepipeline_baseline" {
+  statement {
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+    ]
+
+    resources = [
+      "${var.svcs_account_artifact_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+
+    actions = [
+      "s3:GetBucket*"
+    ]
+
+    resources = [
+      var.svcs_account_artifact_bucket_arn
+    ]
+  }
+
+  statement {
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"      
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artifact.arn}/*"
+    ]
+  }
+
+  statement {
+
+    actions = [
+      "kms:Decrypt"
+    ]
+
+    resources = [
+      var.svcs_account_kms_cmk_arn_for_s3
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_baseline" {
+  name   = "codepipeline-cd-baseline-${var.name}"
+  role   = aws_iam_role.codepipeline.id
+  policy = data.aws_iam_policy_document.codepipeline_baseline.json
+}
+
+data "aws_iam_policy_document" "codepipeline_lambda" {
+  count = var.deploy_type == "lambda" ? 1 : 0
+  statement {
+    actions   = ["lambda:InvokeFunction"]
+    resources = ["arn:aws:lambda:${local.account_region}:${local.account_id}:function:${var.deploy_function_name}"]
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_lambda" {
+  count = var.deploy_type == "lambda" ? 1 : 0
+  name   = "codepipeline-cd-lambda-${var.name}"
+  role   = aws_iam_role.codepipeline.id
+  policy = data.aws_iam_policy_document.codepipeline_lambda[0].json
+}
+
+data "aws_iam_policy_document" "codepipeline_ecs" {
+  count = var.deploy_type == "ecs" ? 1 : 0
+  statement {
+    actions   = ["ecr:DescribeImages"]
+    resources = [var.svcs_account_ecr_repository_arn]
+  }
+
+  statement {
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTaskDefinition",
+      "ecs:DescribeTasks",
+      "ecs:ListTasks",
+      "ecs:RegisterTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = ["ecs:UpdateService"]
+    resources = [
+      "arn:aws:ecs:${local.account_region}:${local.account_id}:service/${var.ecs_cluster_name}/${var.ecs_service_name}"
+    ]
+  }
+
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${local.account_id}:role/${local.task_execution_role}"]
+  }
+}
+
+resource "aws_iam_role_policy" "codepipeline_ecs" {
+  count = var.deploy_type == "ecs" ? 1 : 0
+  name   = "codepipeline-cd-ecs-${var.name}"
+  role   = aws_iam_role.codepipeline.id
+  policy = data.aws_iam_policy_document.codepipeline_ecs[0].json
+}
+
+resource "aws_codepipeline" "pipeline" {
+  name     = var.name
+  role_arn = aws_iam_role.codepipeline.arn
+  artifact_store {
+    location = aws_s3_bucket.artifact.id
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "S3"
+      version          = "1"
+      output_artifacts = [local.codepipeline_artifact_name]
+
+      configuration = {
+        S3Bucket              = var.svcs_account_artifact_bucket_id
+        S3ObjectKey           = var.svcs_account_artifact_object_name
+        PollForSourceChanges = "true"
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.deploy_type == "lambda" ? [1] : []
+    content {
+      name = "Deploy"
+
+      action {
+        name            = "Deploy"
+        category        = "Invoke"
+        owner           = "AWS"
+        provider        = "Lambda"
+        input_artifacts = [local.codepipeline_artifact_name]
+        version         = "1"
+
+        configuration = {
+          FunctionName   = var.deploy_function_name
+          UserParameters = "function_name=${var.lambda_function_name},alias=${var.lambda_function_alias}"
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.deploy_type == "ecs" ? [1]: []
+    content {
+      name = "Deploy"
+
+      action {
+        name            = "Deploy"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "ECS"
+        input_artifacts = [local.codepipeline_artifact_name]
+        version         = "1"
+
+        configuration = {
+          ClusterName = var.ecs_cluster_name
+          ServiceName = var.ecs_service_name
+          FileName    = var.ecs_artifact_filename
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,10 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_region  = data.aws_region.current.name
+  account_id      = data.aws_caller_identity.current.account_id
+
+  task_execution_role = var.task_execution_role == "ecsTaskExecutionRole" ? "ecsTaskExecutionRole" : var.task_execution_role
+  codepipeline_artifact_name = var.deploy_type == "lambda" ? "function_zip" : "imagedefinitions_file"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,15 @@
+output "codepipeline_id" {
+  value = aws_codepipeline.pipeline.id
+}
+
+output "codepipeline_arn" {
+  value = aws_codepipeline.pipeline.arn
+}
+
+output "artifact_bucket_id" {
+  value = aws_s3_bucket.artifact.id
+}
+
+output "artifact_bucket_arn" {
+  value = aws_s3_bucket.artifact.arn
+}

--- a/s3.tf
+++ b/s3.tf
@@ -2,6 +2,7 @@ resource "aws_s3_bucket" "artifact" {
   # S3 bucket cannot be longer than 63 characters and cannot end with dash
   bucket = trimsuffix(lower(substr("codepipeline-cd-${local.account_region}-${local.account_id}-${var.name}", 0, 63)), "-")
   acl    = "private"
+  force_destroy = var.s3_bucket_force_destroy
 
   lifecycle_rule {
     enabled = true

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "artifact" {
+  # S3 bucket cannot be longer than 63 characters and cannot end with dash
+  bucket = trimsuffix(lower(substr("codepipeline-cd-${local.account_region}-${local.account_id}-${var.name}", 0, 63)), "-")
+  acl    = "private"
+
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 90
+    }
+  }
+
+  tags = var.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,129 @@
+variable "name" {
+  type        = string
+  description = "(Required) The name associated with the pipeline and assoicated resources. i.e.: app-name."
+}
+
+variable "deploy_type" {
+  type        = string
+  description = "(Required) Must be one of the following ( ecs, lambda )."
+}
+
+variable "tags" {
+  type        = map
+  description = "(Optional) A mapping of tags to assign to the resource."
+  default     = {}
+}
+
+variable "svcs_account_artifact_bucket_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The ARN of the S3 bucket that stores the codebuild artifacts.
+                The bucket is created in the shared service account.
+                Required if var.deploy_type is lambda or ecs.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_artifact_bucket_id" {
+  type        = string
+  description = <<EOT
+                (Optional) The name of the S3 bucket that stores the codebuild artifacts.
+                The bucket is created in the shared service account.
+                Required if var.deploy_type is lambda or ecs.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_artifact_object_name" {
+  type        = string
+  description = <<EOT
+                (Optional) The key of the S3 object that triggers codepipeline.
+                The object is created in the shared service account.
+                Required if var.deploy_type is lambda or ecs.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_kms_cmk_arn_for_s3" {
+  type        = string
+  description = <<EOT
+                (Optional) The single-region AWS KMS customer managed key ARN for encrypting s3 artifacts.
+                The key is created in the shared service account.
+                Required if var.deploy_type is lambda or ecs.
+                EOT
+  default     = null
+}
+
+variable "lambda_function_name" {
+  type        = string
+  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
+  default     = null
+}
+
+variable "lambda_function_alias" {
+  type        = string
+  description = <<EOT
+                (Optional) The name of the Lambda function alias that gets passed to the UserParameters data in the deploy stage.
+                EOT
+  default     = "live"
+}
+
+variable "deploy_function_name" {
+  type        = string
+  description = "(Optional) The name of the Lambda function in the account that will update the function code."
+  default     = "CodepipelineDeploy"
+}
+
+variable "ecs_cluster_name" {
+  type        = string
+  description = "(Optional) The name of the ECS cluster. Required if var.deploy_type is ecs."
+  default     = null
+}
+
+variable "ecs_service_name" {
+  type        = string
+  description = "(Optional) The name of the ECS service. Required if var.deploy_type is ecs."
+  default     = null
+}
+
+variable "ecs_artifact_filename" {
+  type        = string
+  description = "(Optional) The name of the ECS deploy artifact."
+  default     = null
+}
+
+variable "task_execution_role" {
+  type        = string
+  description = "(Optional) The name of the ECS task execution role. Required if var.deploy_type is ecs."
+  default     = "ecsTaskExecutionRole"
+}
+
+variable "svcs_account_ecr_repository_name" {
+  type        = string
+  description = <<EOT
+                (Optional) The name of the ECR repository.
+                The repository is created in the shared service account.
+                Required if var.deploy_type is ecs.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_ecr_repository_url" {
+  type        = string
+  description = <<EOT
+                (Optional) The URL of the ECR repository.
+                The repository is created in the shared service account.
+                Required if var.deploy_type is ecs.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_ecr_repository_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The ARN of the ECR repository.
+                The repository is created in the shared service account.
+                Required if var.deploy_type is ecs.                
+                EOT
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -152,15 +152,6 @@ variable "approve_sns_arn" {
   default = null
 }
 
-variable "approve_sns_email_subscriptions" {
-  type = list(string)
-  description = <<EOT
-                (Optional) The list of email subscriptions to add to the approval SNS topic.
-                Required if var.require_manual_approval is true.
-                EOT
-  default = []
-}
-
 variable "approve_url" {
     type = string
     description = "(Optional) The URL for review in the approve stage. It should begin with 'http://' or 'https://'."

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,15 @@ variable "svcs_account_kms_cmk_arn_for_s3" {
   default     = null
 }
 
+variable "s3_bucket_force_destroy" {
+  type        = bool
+  description = <<EOT
+                (Optional) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
+                Defaults to true.
+                EOT
+  default     = true
+}
+
 variable "lambda_function_name" {
   type        = string
   description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
@@ -126,4 +135,34 @@ variable "svcs_account_ecr_repository_arn" {
                 Required if var.deploy_type is ecs.                
                 EOT
   default     = null
+}
+
+variable "require_manual_approval" {
+    type = bool
+    description = "(Optional) Create the approval stage in the codepipeline. Defaults to false."
+    default = false
+}
+
+variable "approve_sns_arn" {
+  type = string
+  description = <<EOT
+                (Optional) The ARN of the SNS topic in the approve stage.
+                Required if var.require_manual_approval is true.
+                EOT
+  default = null
+}
+
+variable "approve_sns_email_subscriptions" {
+  type = list(string)
+  description = <<EOT
+                (Optional) The list of email subscriptions to add to the approval SNS topic.
+                Required if var.require_manual_approval is true.
+                EOT
+  default = []
+}
+
+variable "approve_url" {
+    type = string
+    description = "(Optional) The URL for review in the approve stage. It should begin with 'http://' or 'https://'."
+    default = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
#### PR description

What is it for?
The change is to add the TF module templates for the CD(deployment) AWS code pipeline in each client specific account.
All artifacts generated from code build will be stored in the shared service account and accessed by resources in the client specific accounts.

#### Testing instructions

- Sample usage of the module can be found at:
   - For Virginia lambda: https://github.com/globeandmail/curator-infra/blob/DSOPS-3/curator/multi-account_lambda_codepipeline.tf#L289
   - For Virginia ECS: https://github.com/globeandmail/curator-infra/blob/DSOPS-3-ecs/curator/multi-account_ecs_codepipeline.tf#L168
   - For Ireland lambda:https://github.com/globeandmail/sophi-pop-infra/blob/DSOPS-3/multi-account_lambda_codepipeline.tf#L240
   - For Ireland ECS: https://github.com/globeandmail/sophi-pop-infra/blob/DSOPS-3-ecs/multi-account_ecs_codepipeline.tf#L167

#### JIRA ticket information

Story: [DSOPS-3](https://jira.theglobeandmail.com/browse/DSOPS-3)